### PR TITLE
Ignore ZooKeeper znode Create if the path already exists

### DIFF
--- a/core/internal/helpers/zookeeper.go
+++ b/core/internal/helpers/zookeeper.go
@@ -120,6 +120,11 @@ func (z *BurrowZookeeperClient) GetW(path string) ([]byte, *zk.Stat, <-chan zk.E
 	return z.client.GetW(path)
 }
 
+// Exists returns a boolean stating whether or not the specified path exists.
+func (z *BurrowZookeeperClient) Exists(path string) (bool, *zk.Stat, error) {
+	return z.client.Exists(path)
+}
+
 // ExistsW returns a boolean stating whether or not the specified path exists. This method also sets a watch on the node
 // (exists if it does not currently exist, or a data watch otherwise), providing an event channel that will receive a
 // message when the watch fires
@@ -177,6 +182,12 @@ func (m *MockZookeeperClient) ChildrenW(path string) ([]string, *zk.Stat, <-chan
 func (m *MockZookeeperClient) GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error) {
 	args := m.Called(path)
 	return args.Get(0).([]byte), args.Get(1).(*zk.Stat), args.Get(2).(<-chan zk.Event), args.Error(3)
+}
+
+// Exists mocks protocol.ZookeeperClient.Exists
+func (m *MockZookeeperClient) Exists(path string) (bool, *zk.Stat, error) {
+	args := m.Called(path)
+	return args.Bool(0), args.Get(1).(*zk.Stat), args.Error(2)
 }
 
 // ExistsW mocks protocol.ZookeeperClient.ExistsW

--- a/core/internal/zookeeper/coordinator.go
+++ b/core/internal/zookeeper/coordinator.go
@@ -124,10 +124,16 @@ func (zc *Coordinator) createRecursive(path string) error {
 
 	parts := strings.Split(path, "/")
 	for i := 2; i <= len(parts); i++ {
-		_, err := zc.App.Zookeeper.Create(strings.Join(parts[:i], "/"), []byte{}, 0, zk.WorldACL(zk.PermAll))
-		// Ignore when the node exists already
-		if (err != nil) && (err != zk.ErrNodeExists) {
-			return err
+		// If the rootpath exists, skip the Create process to avoid "zk: not authenticated" error
+		exist, _, errExists := zc.App.Zookeeper.Exists(strings.Join(parts[:i], "/"))
+		if !exist {
+			_, err := zc.App.Zookeeper.Create(strings.Join(parts[:i], "/"), []byte{}, 0, zk.WorldACL(zk.PermAll))
+			// Ignore when the node exists already
+			if (err != nil) && (err != zk.ErrNodeExists) {
+				return err
+			}
+		} else {
+			return errExists
 		}
 	}
 	return nil

--- a/core/protocol/protocol.go
+++ b/core/protocol/protocol.go
@@ -141,13 +141,17 @@ type ZookeeperClient interface {
 	// the children of the specified path, providing an event channel that will receive a message when the watch fires
 	GetW(path string) ([]byte, *zk.Stat, <-chan zk.Event, error)
 
+	// For the given path in Zookeeper, return a boolean stating whether or not the node exists.
+	// The method does not set watch on the node, but verifies existence of a node to avoid authentication error.
+	Exists(path string) (bool, *zk.Stat, error)
+
 	// For the given path in Zookeeper, return a boolean stating whether or not the node exists. This method also sets
 	// a watch on the node (exists if it does not currently exist, or a data watch otherwise), providing an event
 	// channel that will receive a message when the watch fires
 	ExistsW(path string) (bool, *zk.Stat, <-chan zk.Event, error)
 
 	// Create makes a new ZNode at the specified path with the contents set to the data byte-slice. Flags can be
-	// provided to specify that this is an ephemeral or sequence node, and an ACL must be provided. If no ACL is\
+	// provided to specify that this is an ephemeral or sequence node, and an ACL must be provided. If no ACL is
 	// desired, specify
 	//  zk.WorldACL(zk.PermAll)
 	Create(string, []byte, int32, []zk.ACL) (string, error)


### PR DESCRIPTION
Currently, Burrow will attempt to create the znode used by Burrow on startup
This will cause problems if there is authentication needed when connecting
to zk.

The fix is to ignore creating zk node paths if it already exists